### PR TITLE
Add: Added query parameters when sending API  event

### DIFF
--- a/sendmoesif.go
+++ b/sendmoesif.go
@@ -19,10 +19,15 @@ func sendMoesifAsync(request *http.Request, reqTime time.Time, reqHeader map[str
 	// Get Client Ip
 	ip := getClientIp(request)
 
+	uri := request.URL.Scheme + "://" + request.Host + request.URL.Path
+	if request.URL.RawQuery != "" {
+		uri += "?" + request.URL.RawQuery
+	}
+
 	// Prepare request model
 	event_request := models.EventRequestModel{
 		Time:             &reqTime,
-		Uri:              request.URL.Scheme + "://" + request.Host + request.URL.Path,
+		Uri:              uri,
 		Verb:             request.Method,
 		ApiVersion:       apiVersion,
 		IpAddress:        &ip,
@@ -80,7 +85,7 @@ func sendMoesifAsync(request *http.Request, reqTime time.Time, reqHeader map[str
 			}
 		}
 	} else {
-		if debug{
+		if debug {
 			log.Println("Skipped Event due to sampling percentage: " + strconv.Itoa(samplingPercentage) + " and random percentage: " + strconv.Itoa(randomPercentage))
 		}
 	}


### PR DESCRIPTION
Query parameters are not reaching Moesif, they weren't being sent. This PR adds them, if present.

Query params are not included in `URL.Path`.
<img width="652" alt="Screenshot 2023-11-15 at 4 07 19 PM" src="https://github.com/Moesif/moesifmiddleware-go/assets/17258946/07dd7fd8-c7bf-4e8d-b2c1-d2e1aa754b12">

According to API-Reference, this is supported:
<img width="735" alt="Screenshot 2023-11-15 at 4 08 29 PM" src="https://github.com/Moesif/moesifmiddleware-go/assets/17258946/b8434800-e6eb-40eb-92bc-4efc2435f09f">


